### PR TITLE
Increment build number for skiped maven 3.9.7 ver

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "scyjava" %}
 {% set version = "1.10.0" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR changes the `scyjava` recipe on conda-forge to skip maven version `3.9.7`. This version fails to pull in dependencies from the repositories. Versions lower than `3.9.7` have are unaffected. This issue is marked resolved in version `3.9.8`. Extra note, I accidentally pushed the recipe change w/o the build increment to `conda-forge/scyjava-feedstock` instead of my fork. Oops!

<!--
Please add any other relevant info below:
-->
